### PR TITLE
Disallow nesting by default, providing an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ logger = Alephant::Logger.setup json_driver
 logger.info({ "some_field" => "some_value", "other_field" => "other_value" })
 ```
 
+By default, nested JSON values are flattened to strings.  To enable nesting,
+provided that your log analysis tooling supports that, create
+`Alephant::Logger::JSON` as follows:
+```
+Alephant::Logger::JSON.new("path/to/logfile.log", :nesting => true)
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/BBC-News/alephant-logger-json/fork )

--- a/lib/alephant/logger/json.rb
+++ b/lib/alephant/logger/json.rb
@@ -6,7 +6,7 @@ module Alephant
       def initialize(log_path, options = {})
         @log_file = File.open(log_path, "a+")
         @log_file.sync = true
-        @nesting = options.fetch(:nesting) { false }
+        @nesting = options.fetch(:nesting, false)
       end
 
       private

--- a/lib/alephant/logger/json.rb
+++ b/lib/alephant/logger/json.rb
@@ -3,14 +3,26 @@ require "json"
 module Alephant
   module Logger
     class JSON
-      def initialize(log_path)
+      def initialize(log_path, allow_nesting = false)
         @log_file = File.open(log_path, "a+")
         @log_file.sync = true
+        @allow_nesting = allow_nesting
       end
+
+      private
+
+      def flatten_values_to_s(hash)
+        Hash[hash.map { |k, v| [k, v.to_s] }]
+      end
+
+      public
 
       [:debug, :info, :warn, :error].each do |level|
         define_method(level) do |hash|
           hash["level"] = level.to_s
+
+          hash = flatten_values_to_s hash if not @allow_nesting
+
           @log_file.write(::JSON.generate(hash) + "\n")
         end
       end

--- a/lib/alephant/logger/json.rb
+++ b/lib/alephant/logger/json.rb
@@ -3,10 +3,10 @@ require "json"
 module Alephant
   module Logger
     class JSON
-      def initialize(log_path, allow_nesting = false)
+      def initialize(log_path, options = {})
         @log_file = File.open(log_path, "a+")
         @log_file.sync = true
-        @allow_nesting = allow_nesting
+        @nesting = options.fetch(:nesting) { false }
       end
 
       private
@@ -21,7 +21,7 @@ module Alephant
         define_method(level) do |hash|
           hash["level"] = level.to_s
 
-          hash = flatten_values_to_s hash if not @allow_nesting
+          hash = flatten_values_to_s hash if not @nesting
 
           @log_file.write(::JSON.generate(hash) + "\n")
         end

--- a/spec/alephant/logger/json_spec.rb
+++ b/spec/alephant/logger/json_spec.rb
@@ -71,7 +71,7 @@ describe Alephant::Logger::JSON do
 
       context "with nesting allowed" do
         subject do
-          described_class.new(log_path, true)
+          described_class.new(log_path, :nesting => true)
         end
 
         it_behaves_like "nesting allowed"

--- a/spec/alephant/logger/json_spec.rb
+++ b/spec/alephant/logger/json_spec.rb
@@ -63,22 +63,18 @@ describe Alephant::Logger::JSON do
 
   %w[debug info warn error].each do |level|
     describe "##{level}" do
-      it_behaves_like "JSON logging" do
-        let(:level) { level }
-      end
+      let(:level) { level }
 
-      it_behaves_like "nests flattened to strings" do
-        let(:level) { level }
-      end
+      it_behaves_like "JSON logging"
+
+      it_behaves_like "nests flattened to strings"
 
       context "with nesting allowed" do
         subject do
           described_class.new(log_path, true)
         end
 
-        it_behaves_like "nesting allowed" do
-          let(:level) { level }
-        end
+        it_behaves_like "nesting allowed"
       end
     end
   end


### PR DESCRIPTION
![langton](http://upload.wikimedia.org/wikipedia/commons/a/a3/MulticolorLangtonsAnt.gif)

# Problem

Log analysis tooling does not universally support nested logs; nested data could cause runtime exceptions.

# Solution
`Alephant::Logger::JSON` now accepts an optional options hash for its second constructor parameter - `:nesting => true` enables nesting.  Without this option enabled, all values undergo stringification so that any nested hashes are saved as string notation.

```ruby
Alephant::Logger::JSON.new("logfile.txt", :nesting => true)
```