### PR TITLE
Log calling methods

### DIFF
--- a/alephant-logger-json.gemspec
+++ b/alephant-logger-json.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "binding_of_caller"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
![nunchaku](https://38.media.tumblr.com/cfde4ec1bda8cec6c6f5cfa5c470cd89/tumblr_mp0znchqdI1s9816mo1_500.gif)


# Problem

To facilitate tracing application issues in logs, an overly duplicative pattern of logging method names has emerged in consuming applications,  e.g.
```ruby
class Bar
  def qux
    logger.info("foo" => "bar", "method" => "Baz#qux")
  end
end
```

# Solution

Remove the need for duplication.  Provide a `:log_methods` option key for the `Alephant::Logger::JSON` constructor, which adds a `method` key to subsequent JSON logs, populated by programmatically examining the calling context.

```ruby
Alephant::Logger::JSON.new("/path/to/log", method_logging: true)
```

I have benchmarked this to examine the performance implications.  Enabling this option demonstrated a negligible performance impact for me.  For reference:

```ruby
require "benchmark"
require "alephant/logger/json"

n = 2_000_000

methods    = Alephant::Logger::JSON.new("/dev/null", method_logging: true)
no_methods = Alephant::Logger::JSON.new("/dev/null")

log_hash = { lol: "whut" }

Benchmark.bm do |x|
  x.report { n.times do; methods.info log_hash; end }
  x.report { n.times do; no_methods.info log_hash; end }
end
```

```
  user     system      total        real
  16.420000   1.330000  17.750000 ( 18.197274)
  16.430000   1.310000  17.740000 ( 18.066493)
```