### PR TITLE
Add a logger for logging to an IO object

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require "bundler/gem_tasks"
-require "rake/rspec"
+require 'bundler/gem_tasks'
+require 'rake/rspec'
 
-task :default => :spec
+task default: :spec

--- a/alephant-logger-json.gemspec
+++ b/alephant-logger-json.gemspec
@@ -1,27 +1,27 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "alephant/logger/json/version"
+require 'alephant/logger/json/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "alephant-logger-json"
+  spec.name          = 'alephant-logger-json'
   spec.version       = Alephant::Logger::JSON::VERSION
-  spec.authors       = ["Dan Arnould"]
-  spec.email         = ["dan@arnould.co.uk"]
-  spec.summary       = "alephant-logger driver enabling structured logging in JSON"
-  spec.description   = "alephant-logger driver enabling structured logging in JSON"
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.authors       = ['Dan Arnould']
+  spec.email         = ['dan@arnould.co.uk']
+  spec.summary       = 'alephant-logger driver enabling structured logging in JSON'
+  spec.description   = 'alephant-logger driver enabling structured logging in JSON'
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rspec-nc"
-  spec.add_development_dependency "rake-rspec"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec-nc'
+  spec.add_development_dependency 'rake-rspec'
+  spec.add_development_dependency 'pry'
 end

--- a/lib/alephant/logger/dynamic_binding.rb
+++ b/lib/alephant/logger/dynamic_binding.rb
@@ -7,7 +7,7 @@ module DynamicBinding
     def method_missing(m, *args)
       @bindings.reverse_each do |bind|
         begin
-          method = eval("method(%s)" % m.inspect, bind)
+          method = eval('method(%s)' % m.inspect, bind)
         rescue NameError
         else
           return method.call(*args)
@@ -18,7 +18,7 @@ module DynamicBinding
         rescue NameError
         end
       end
-      raise NoMethodError, "No such variable or method: %s" % m
+      raise NoMethodError, 'No such variable or method: %s' % m
     end
 
     def run_proc(p, *args)

--- a/lib/alephant/logger/json.rb
+++ b/lib/alephant/logger/json.rb
@@ -5,22 +5,25 @@ module Alephant
   module Logger
     class JSON
       def initialize(log_path, options = {})
-        @log_file = File.open(log_path, "a+")
+        @log_file      = File.open(log_path, "a+")
         @log_file.sync = true
-        @nesting = options.fetch(:nesting, false)
+        @nesting       = options.fetch(:nesting, false)
+        @@session      = -> { "n/a" } unless defined? @@session
       end
 
       [:debug, :info, :warn, :error].each do |level|
-        define_method(level) do |b=nil, hash|
+        define_method(level) do |b = nil, hash|
           return if hash.is_a? String
-          @@session = -> { "n/a" } unless defined? @@session
+
           h = {
-            :timestamp => Time.now.to_s,
-            :uuid      => b.nil? ? "n/a" : @@session.call_with_binding(b),
-            :level     => level.to_s
-          }.merge hash
-          hash = flatten_values_to_s h unless @nesting
-          @log_file.write(::JSON.generate(hash) + "\n")
+            timestamp: Time.now.to_s,
+            uuid:      b.nil? ? 'n/a' : @@session.call_with_binding(b),
+            level:     level.to_s
+          }.merge(hash)
+
+          hash = flatten_values_to_s(h) unless @nesting
+
+          write(hash)
         end
       end
 
@@ -33,6 +36,10 @@ module Alephant
       end
 
       private
+
+      def write(hash)
+        @log_file.write(::JSON.generate(hash) + "\n")
+      end
 
       def flatten_values_to_s(hash)
         Hash[hash.map { |k, v| [k, v.to_s] }]

--- a/lib/alephant/logger/json.rb
+++ b/lib/alephant/logger/json.rb
@@ -5,10 +5,10 @@ module Alephant
   module Logger
     class JSON
       def initialize(log_path, options = {})
-        @log_file      = File.open(log_path, "a+")
-        @log_file.sync = true
-        @nesting       = options.fetch(:nesting, false)
-        @@session      = -> { "n/a" } unless defined? @@session
+        @log_file          = File.open(log_path, "a+")
+        @log_file.sync     = true
+        @nesting           = options.fetch(:nesting, false)
+        self.class.session = -> { "n/a" } unless self.class.session?
       end
 
       [:debug, :info, :warn, :error].each do |level|
@@ -17,7 +17,7 @@ module Alephant
 
           h = {
             timestamp: Time.now.to_s,
-            uuid:      b.nil? ? 'n/a' : @@session.call_with_binding(b),
+            uuid:      b.nil? ? 'n/a' : self.class.session.call_with_binding(b),
             level:     level.to_s
           }.merge(hash)
 
@@ -27,12 +27,12 @@ module Alephant
         end
       end
 
-      def self.session(fn)
-        @@session = fn
-      end
+      class << self
+        attr_accessor :session
 
-      def self.session?
-        defined?(@@session)
+        def session?
+          defined?(@session)
+        end
       end
 
       private

--- a/lib/alephant/logger/json.rb
+++ b/lib/alephant/logger/json.rb
@@ -1,14 +1,14 @@
-require_relative "./dynamic_binding.rb"
-require "json"
+require_relative './dynamic_binding.rb'
+require 'json'
 
 module Alephant
   module Logger
     class JSON
       def initialize(log_path, options = {})
-        @log_file          = File.open(log_path, "a+")
+        @log_file          = File.open(log_path, 'a+')
         @log_file.sync     = true
         @nesting           = options.fetch(:nesting, false)
-        self.class.session = -> { "n/a" } unless self.class.session?
+        self.class.session = -> { 'n/a' } unless self.class.session?
       end
 
       [:debug, :info, :warn, :error].each do |level|

--- a/lib/alephant/logger/json/version.rb
+++ b/lib/alephant/logger/json/version.rb
@@ -1,7 +1,7 @@
 module Alephant
   module Logger
     class JSON
-      VERSION = "0.3.1"
+      VERSION = '0.4.0'.freeze
     end
   end
 end

--- a/lib/alephant/logger/json_to_io.rb
+++ b/lib/alephant/logger/json_to_io.rb
@@ -1,0 +1,22 @@
+require_relative 'json'
+require 'json'
+
+module Alephant
+  module Logger
+    class JSONtoIO < Alephant::Logger::JSON
+      attr_reader :output
+
+      def initialize(output, options = {})
+        @output   = output
+        @nesting  = options.fetch(:nesting, false)
+        @@session = -> { 'n/a' } unless defined? @@session
+      end
+
+      private
+
+      def write(hash)
+        output.puts(::JSON.generate(hash))
+      end
+    end
+  end
+end

--- a/lib/alephant/logger/json_to_io.rb
+++ b/lib/alephant/logger/json_to_io.rb
@@ -7,9 +7,9 @@ module Alephant
       attr_reader :output
 
       def initialize(output, options = {})
-        @output   = output
-        @nesting  = options.fetch(:nesting, false)
-        @@session = -> { 'n/a' } unless defined? @@session
+        @output            = output
+        @nesting           = options.fetch(:nesting, false)
+        self.class.session = -> { 'n/a' } unless self.class.session?
       end
 
       private

--- a/spec/alephant/logger/json_spec.rb
+++ b/spec/alephant/logger/json_spec.rb
@@ -1,12 +1,12 @@
-require "date"
-require "spec_helper"
-require "alephant/logger/json"
+require 'date'
+require 'spec_helper'
+require 'alephant/logger/json'
 
 describe Alephant::Logger::JSON do
   subject { described_class.new(log_path) }
 
-  let(:fn)       { -> { "foo" } }
-  let(:log_path) { "/log/path.log" }
+  let(:fn)       { -> { 'foo' } }
+  let(:log_path) { '/log/path.log' }
   let(:log_file) { instance_double File }
 
   before do
@@ -14,32 +14,32 @@ describe Alephant::Logger::JSON do
     allow(log_file).to receive :sync=
   end
 
-  shared_examples "JSON logging" do
+  shared_examples 'JSON logging' do
     let(:log_hash) do
-      { "foo" => "bar", "baz" => "quux" }
+      { 'foo' => 'bar', 'baz' => 'quux' }
     end
 
-    it "writes JSON dump of hash to log with corresponding level key" do
-      allow(Time).to receive(:now).and_return("foobar")
+    it 'writes JSON dump of hash to log with corresponding level key' do
+      allow(Time).to receive(:now).and_return('foobar')
 
       expect(log_file).to receive(:write) do |json_dump|
-        h = { "timestamp" => "foobar", "uuid" => "n/a", "level" => level }
-        expect(JSON.parse json_dump).to eq h.merge log_hash
+        h = { 'timestamp' => 'foobar', 'uuid' => 'n/a', 'level' => level }
+        expect(JSON.parse(json_dump)).to eq h.merge log_hash
       end
 
       subject.send(level, log_hash)
     end
 
-    it "automatically includes a timestamp" do
+    it 'automatically includes a timestamp' do
       expect(log_file).to receive(:write) do |json_dump|
-        t = JSON.parse(json_dump)["timestamp"]
-        expect{DateTime.parse(t)}.to_not raise_error
+        t = JSON.parse(json_dump)['timestamp']
+        expect { DateTime.parse(t) }.to_not raise_error
       end
 
       subject.send(level, log_hash)
     end
 
-    it "outputs the timestamp first" do
+    it 'outputs the timestamp first' do
       expect(log_file).to receive(:write) do |json_dump|
         h = JSON.parse(json_dump)
         expect(h.first[0].to_sym).to be :timestamp
@@ -48,69 +48,69 @@ describe Alephant::Logger::JSON do
       subject.send(level, log_hash)
     end
 
-    it "displays a default session value if a custom function is not provided" do
+    it 'displays a default session value if a custom function is not provided' do
       expect(log_file).to receive(:write) do |json_dump|
         h = JSON.parse(json_dump)
-        expect(h["uuid"]).to eq "n/a"
+        expect(h['uuid']).to eq 'n/a'
       end
 
       subject.send(level, log_hash)
     end
 
-    it "displays a custom session value when provided a user defined function" do
+    it 'displays a custom session value when provided a user defined function' do
       expect(log_file).to receive(:write) do |json_dump|
         h = JSON.parse(json_dump)
-        expect(h["uuid"]).to eq "foo"
+        expect(h['uuid']).to eq 'foo'
       end
 
       described_class.session = fn
       subject.send(level, binding, log_hash)
-      described_class.session = -> { "n/a" }
+      described_class.session = -> { 'n/a' }
     end
 
-    it "provides a static method for checking if a session has been set" do
+    it 'provides a static method for checking if a session has been set' do
       described_class.session = fn
-      expect(described_class.session?).to eq "instance-variable"
+      expect(described_class.session?).to eq 'instance-variable'
 
       described_class.remove_instance_variable :@session
       expect(described_class.session?).to eq nil
     end
   end
 
-  shared_context "nested log hash" do
+  shared_context 'nested log hash' do
     let(:log_hash) do
-      { "nest" => nest }
+      { 'nest' => nest }
     end
 
-    let(:nest) { { "bird" => "eggs" } }
+    let(:nest) { { 'bird' => 'eggs' } }
   end
 
-  shared_examples "nests flattened to strings" do
-    include_context "nested log hash"
+  shared_examples 'nests flattened to strings' do
+    include_context 'nested log hash'
 
     specify do
       expect(log_file).to receive(:write) do |json_dump|
-        expect(JSON.parse(json_dump)["nest"]).to eq nest.to_s
+        expect(JSON.parse(json_dump)['nest']).to eq nest.to_s
       end
 
       subject.send(level, log_hash)
     end
   end
 
-  shared_examples "nesting allowed" do
-    include_context "nested log hash"
+  shared_examples 'nesting allowed' do
+    include_context 'nested log hash'
 
     specify do
       expect(log_file).to receive(:write) do |json_dump|
-        expect(JSON.parse json_dump).to eq log_hash
+        expect(JSON.parse(json_dump)).to eq log_hash
       end
 
       subject.send(level, log_hash)
     end
   end
 
-  shared_examples "gracefully fail with string arg" do
-    let(:log_message) { "Unable to connect to server" }
+  shared_examples 'gracefully fail with string arg' do
+    let(:log_message) { 'Unable to connect to server' }
 
     specify { expect(log_file).not_to receive(:write) }
     specify do
@@ -122,18 +122,18 @@ describe Alephant::Logger::JSON do
     describe "##{level}" do
       let(:level) { level }
 
-      it_behaves_like "JSON logging"
+      it_behaves_like 'JSON logging'
 
-      it_behaves_like "nests flattened to strings"
+      it_behaves_like 'nests flattened to strings'
 
-      it_behaves_like "gracefully fail with string arg"
+      it_behaves_like 'gracefully fail with string arg'
 
-      context "with nesting allowed" do
+      context 'with nesting allowed' do
         subject do
-          described_class.new(log_path, :nesting => true)
+          described_class.new(log_path, nesting: true)
         end
 
-        it_behaves_like "nesting allowed"
+        it_behaves_like 'nesting allowed'
       end
     end
   end

--- a/spec/alephant/logger/json_spec.rb
+++ b/spec/alephant/logger/json_spec.rb
@@ -3,9 +3,7 @@ require "spec_helper"
 require "alephant/logger/json"
 
 describe Alephant::Logger::JSON do
-  subject do
-    described_class.new log_path
-  end
+  subject { described_class.new(log_path) }
 
   let(:fn)       { -> { "foo" } }
   let(:log_path) { "/log/path.log" }
@@ -65,17 +63,17 @@ describe Alephant::Logger::JSON do
         expect(h["uuid"]).to eq "foo"
       end
 
-      ::Alephant::Logger::JSON.session fn
+      described_class.session = fn
       subject.send(level, binding, log_hash)
-      ::Alephant::Logger::JSON.session -> { "n/a" }
+      described_class.session = -> { "n/a" }
     end
 
     it "provides a static method for checking if a session has been set" do
-      ::Alephant::Logger::JSON.session fn
-      expect(::Alephant::Logger::JSON.session?).to eq "class variable"
+      described_class.session = fn
+      expect(described_class.session?).to eq "instance-variable"
 
-      ::Alephant::Logger::JSON.remove_class_variable :@@session
-      expect(::Alephant::Logger::JSON.session?).to eq nil
+      described_class.remove_instance_variable :@session
+      expect(described_class.session?).to eq nil
     end
   end
 

--- a/spec/alephant/logger/json_spec.rb
+++ b/spec/alephant/logger/json_spec.rb
@@ -72,7 +72,7 @@ describe Alephant::Logger::JSON do
       described_class.session = fn
       expect(described_class.session?).to eq 'instance-variable'
 
-      described_class.remove_instance_variable :@session
+      described_class.send(:remove_instance_variable, :@session)
       expect(described_class.session?).to eq nil
     end
   end

--- a/spec/alephant/logger/json_to_io_spec.rb
+++ b/spec/alephant/logger/json_to_io_spec.rb
@@ -57,17 +57,17 @@ describe Alephant::Logger::JSONtoIO do
         expect(h["uuid"]).to eq "foo"
       end
 
-      ::Alephant::Logger::JSON.session fn
-      subject.public_send(level, binding, log_hash)
-      ::Alephant::Logger::JSON.session -> { "n/a" }
+      described_class.session = fn
+      subject.send(level, binding, log_hash)
+      described_class.session = -> { "n/a" }
     end
 
     it "provides a static method for checking if a session has been set" do
-      ::Alephant::Logger::JSON.session fn
-      expect(::Alephant::Logger::JSON.session?).to eq "class variable"
+      described_class.session = fn
+      expect(described_class.session?).to eq "instance-variable"
 
-      ::Alephant::Logger::JSON.remove_class_variable :@@session
-      expect(::Alephant::Logger::JSON.session?).to eq nil
+      described_class.remove_instance_variable :@session
+      expect(described_class.session?).to eq nil
     end
   end
 

--- a/spec/alephant/logger/json_to_io_spec.rb
+++ b/spec/alephant/logger/json_to_io_spec.rb
@@ -1,39 +1,39 @@
-require "date"
-require "spec_helper"
-require "alephant/logger/json_to_io"
+require 'date'
+require 'spec_helper'
+require 'alephant/logger/json_to_io'
 
 describe Alephant::Logger::JSONtoIO do
   subject { described_class.new(logger_io) }
 
-  let(:fn)        { -> { "foo" } }
+  let(:fn)        { -> { 'foo' } }
   let(:logger_io) { spy }
 
-  shared_examples "JSON logging" do
+  shared_examples 'JSON logging' do
     let(:log_hash) do
-      { "foo" => "bar", "baz" => "quux" }
+      { 'foo' => 'bar', 'baz' => 'quux' }
     end
 
-    it "writes JSON dump of hash to log with corresponding level key" do
-      allow(Time).to receive(:now).and_return("foobar")
+    it 'writes JSON dump of hash to log with corresponding level key' do
+      allow(Time).to receive(:now).and_return('foobar')
 
       expect(logger_io).to receive(:puts) do |json_dump|
-        h = { "timestamp" => "foobar", "uuid" => "n/a", "level" => level }
-        expect(JSON.parse json_dump).to eq h.merge log_hash
+        h = { 'timestamp' => 'foobar', 'uuid' => 'n/a', 'level' => level }
+        expect(JSON.parse(json_dump)).to eq h.merge log_hash
       end
 
       subject.public_send(level, log_hash)
     end
 
-    it "automatically includes a timestamp" do
+    it 'automatically includes a timestamp' do
       expect(logger_io).to receive(:puts) do |json_dump|
-        t = JSON.parse(json_dump)["timestamp"]
-        expect{DateTime.parse(t)}.to_not raise_error
+        t = JSON.parse(json_dump)['timestamp']
+        expect { DateTime.parse(t) }.to_not raise_error
       end
 
       subject.public_send(level, log_hash)
     end
 
-    it "outputs the timestamp first" do
+    it 'outputs the timestamp first' do
       expect(logger_io).to receive(:puts) do |json_dump|
         h = JSON.parse(json_dump)
         expect(h.first[0].to_sym).to be :timestamp
@@ -42,69 +42,69 @@ describe Alephant::Logger::JSONtoIO do
       subject.public_send(level, log_hash)
     end
 
-    it "displays a default session value if a custom function is not provided" do
+    it 'displays a default session value if a custom function is not provided' do
       expect(logger_io).to receive(:puts) do |json_dump|
         h = JSON.parse(json_dump)
-        expect(h["uuid"]).to eq "n/a"
+        expect(h['uuid']).to eq 'n/a'
       end
 
       subject.public_send(level, log_hash)
     end
 
-    it "displays a custom session value when provided a user defined function" do
+    it 'displays a custom session value when provided a user defined function' do
       expect(logger_io).to receive(:puts) do |json_dump|
         h = JSON.parse(json_dump)
-        expect(h["uuid"]).to eq "foo"
+        expect(h['uuid']).to eq 'foo'
       end
 
       described_class.session = fn
       subject.send(level, binding, log_hash)
-      described_class.session = -> { "n/a" }
+      described_class.session = -> { 'n/a' }
     end
 
-    it "provides a static method for checking if a session has been set" do
+    it 'provides a static method for checking if a session has been set' do
       described_class.session = fn
-      expect(described_class.session?).to eq "instance-variable"
+      expect(described_class.session?).to eq 'instance-variable'
 
       described_class.remove_instance_variable :@session
       expect(described_class.session?).to eq nil
     end
   end
 
-  shared_context "nested log hash" do
+  shared_context 'nested log hash' do
     let(:log_hash) do
-      { "nest" => nest }
+      { 'nest' => nest }
     end
 
-    let(:nest) { { "bird" => "eggs" } }
+    let(:nest) { { 'bird' => 'eggs' } }
   end
 
-  shared_examples "nests flattened to strings" do
-    include_context "nested log hash"
+  shared_examples 'nests flattened to strings' do
+    include_context 'nested log hash'
 
     specify do
       expect(logger_io).to receive(:puts) do |json_dump|
-        expect(JSON.parse(json_dump)["nest"]).to eq nest.to_s
+        expect(JSON.parse(json_dump)['nest']).to eq nest.to_s
       end
 
       subject.public_send(level, log_hash)
     end
   end
 
-  shared_examples "nesting allowed" do
-    include_context "nested log hash"
+  shared_examples 'nesting allowed' do
+    include_context 'nested log hash'
 
     specify do
       expect(logger_io).to receive(:puts) do |json_dump|
-        expect(JSON.parse json_dump).to eq log_hash
+        expect(JSON.parse(json_dump)).to eq log_hash
       end
 
       subject.public_send(level, log_hash)
     end
   end
 
-  shared_examples "gracefully fail with string arg" do
-    let(:log_message) { "Unable to connect to server" }
+  shared_examples 'gracefully fail with string arg' do
+    let(:log_message) { 'Unable to connect to server' }
 
     specify { expect(logger_io).not_to receive(:puts) }
     specify do
@@ -116,16 +116,16 @@ describe Alephant::Logger::JSONtoIO do
     describe "##{level}" do
       let(:level) { level }
 
-      it_behaves_like "JSON logging"
+      it_behaves_like 'JSON logging'
 
-      it_behaves_like "nests flattened to strings"
+      it_behaves_like 'nests flattened to strings'
 
-      it_behaves_like "gracefully fail with string arg"
+      it_behaves_like 'gracefully fail with string arg'
 
-      context "with nesting allowed" do
+      context 'with nesting allowed' do
         subject { described_class.new(logger_io, nesting: true) }
 
-        it_behaves_like "nesting allowed"
+        it_behaves_like 'nesting allowed'
       end
     end
   end

--- a/spec/alephant/logger/json_to_io_spec.rb
+++ b/spec/alephant/logger/json_to_io_spec.rb
@@ -1,0 +1,132 @@
+require "date"
+require "spec_helper"
+require "alephant/logger/json_to_io"
+
+describe Alephant::Logger::JSONtoIO do
+  subject { described_class.new(logger_io) }
+
+  let(:fn)        { -> { "foo" } }
+  let(:logger_io) { spy }
+
+  shared_examples "JSON logging" do
+    let(:log_hash) do
+      { "foo" => "bar", "baz" => "quux" }
+    end
+
+    it "writes JSON dump of hash to log with corresponding level key" do
+      allow(Time).to receive(:now).and_return("foobar")
+
+      expect(logger_io).to receive(:puts) do |json_dump|
+        h = { "timestamp" => "foobar", "uuid" => "n/a", "level" => level }
+        expect(JSON.parse json_dump).to eq h.merge log_hash
+      end
+
+      subject.public_send(level, log_hash)
+    end
+
+    it "automatically includes a timestamp" do
+      expect(logger_io).to receive(:puts) do |json_dump|
+        t = JSON.parse(json_dump)["timestamp"]
+        expect{DateTime.parse(t)}.to_not raise_error
+      end
+
+      subject.public_send(level, log_hash)
+    end
+
+    it "outputs the timestamp first" do
+      expect(logger_io).to receive(:puts) do |json_dump|
+        h = JSON.parse(json_dump)
+        expect(h.first[0].to_sym).to be :timestamp
+      end
+
+      subject.public_send(level, log_hash)
+    end
+
+    it "displays a default session value if a custom function is not provided" do
+      expect(logger_io).to receive(:puts) do |json_dump|
+        h = JSON.parse(json_dump)
+        expect(h["uuid"]).to eq "n/a"
+      end
+
+      subject.public_send(level, log_hash)
+    end
+
+    it "displays a custom session value when provided a user defined function" do
+      expect(logger_io).to receive(:puts) do |json_dump|
+        h = JSON.parse(json_dump)
+        expect(h["uuid"]).to eq "foo"
+      end
+
+      ::Alephant::Logger::JSON.session fn
+      subject.public_send(level, binding, log_hash)
+      ::Alephant::Logger::JSON.session -> { "n/a" }
+    end
+
+    it "provides a static method for checking if a session has been set" do
+      ::Alephant::Logger::JSON.session fn
+      expect(::Alephant::Logger::JSON.session?).to eq "class variable"
+
+      ::Alephant::Logger::JSON.remove_class_variable :@@session
+      expect(::Alephant::Logger::JSON.session?).to eq nil
+    end
+  end
+
+  shared_context "nested log hash" do
+    let(:log_hash) do
+      { "nest" => nest }
+    end
+
+    let(:nest) { { "bird" => "eggs" } }
+  end
+
+  shared_examples "nests flattened to strings" do
+    include_context "nested log hash"
+
+    specify do
+      expect(logger_io).to receive(:puts) do |json_dump|
+        expect(JSON.parse(json_dump)["nest"]).to eq nest.to_s
+      end
+
+      subject.public_send(level, log_hash)
+    end
+  end
+
+  shared_examples "nesting allowed" do
+    include_context "nested log hash"
+
+    specify do
+      expect(logger_io).to receive(:puts) do |json_dump|
+        expect(JSON.parse json_dump).to eq log_hash
+      end
+
+      subject.public_send(level, log_hash)
+    end
+  end
+
+  shared_examples "gracefully fail with string arg" do
+    let(:log_message) { "Unable to connect to server" }
+
+    specify { expect(logger_io).not_to receive(:puts) }
+    specify do
+      expect { subject.debug log_message }.not_to raise_error
+    end
+  end
+
+  %w(debug info warn error).each do |level|
+    describe "##{level}" do
+      let(:level) { level }
+
+      it_behaves_like "JSON logging"
+
+      it_behaves_like "nests flattened to strings"
+
+      it_behaves_like "gracefully fail with string arg"
+
+      context "with nesting allowed" do
+        subject { described_class.new(logger_io, nesting: true) }
+
+        it_behaves_like "nesting allowed"
+      end
+    end
+  end
+end

--- a/spec/alephant/logger/json_to_io_spec.rb
+++ b/spec/alephant/logger/json_to_io_spec.rb
@@ -66,7 +66,7 @@ describe Alephant::Logger::JSONtoIO do
       described_class.session = fn
       expect(described_class.session?).to eq 'instance-variable'
 
-      described_class.remove_instance_variable :@session
+      described_class.send(:remove_instance_variable, :@session)
       expect(described_class.session?).to eq nil
     end
   end


### PR DESCRIPTION
This PR adds a `JSONtoIO` logger class that allows JSON output to be sent to an arbitrary IO stream (i.e. STDOUT or STDERR).

It also includes a small refactor to remove the use of `@@` class variables, and numerous rubocop updates to match the latest bbc-news standards.