### PR TITLE
Support Ruby 1.x Syntax for JRuby 1.7.x

### DIFF
--- a/lib/alephant/logger/json.rb
+++ b/lib/alephant/logger/json.rb
@@ -44,10 +44,7 @@ module Alephant
       end
 
       def writeable?(message_level)
-        LevelsController.should_log?(
-          message_level: message_level,
-          desired_level: @write_level
-        )
+        LevelsController.should_log?(message_level, @write_level)
       end
 
       def flatten_values_to_s(hash)

--- a/lib/alephant/logger/json/version.rb
+++ b/lib/alephant/logger/json/version.rb
@@ -1,7 +1,7 @@
 module Alephant
   module Logger
     class JSON
-      VERSION = '0.5.0'.freeze
+      VERSION = '0.5.1'.freeze
     end
   end
 end

--- a/lib/alephant/logger/levels_controller.rb
+++ b/lib/alephant/logger/levels_controller.rb
@@ -1,7 +1,7 @@
 module Alephant
   module Logger
     class LevelsController
-      # Ruby 1.x syntax used to support JRuby 1.17.x
+      # Ruby 1.x syntax used to support JRuby 1.7.x
       # rubocop:disable Style/SymbolArray
       LEVELS = [:debug, :info, :warn, :error].freeze
       # rubocop:enable Style/SymbolArray

--- a/lib/alephant/logger/levels_controller.rb
+++ b/lib/alephant/logger/levels_controller.rb
@@ -1,10 +1,13 @@
 module Alephant
   module Logger
     class LevelsController
-      LEVELS = %i(debug info warn error).freeze
+      # Ruby 1.x syntax used to support JRuby 1.17.x
+      # rubocop:disable Style/SymbolArray
+      LEVELS = [:debug, :info, :warn, :error].freeze
+      # rubocop:enable Style/SymbolArray
 
       class << self
-        def should_log?(message_level:, desired_level:)
+        def should_log?(message_level, desired_level)
           message_level_index = level_index(message_level)
 
           return false unless message_level_index

--- a/spec/alephant/logger/levels_controller_spec.rb
+++ b/spec/alephant/logger/levels_controller_spec.rb
@@ -5,10 +5,7 @@ require_relative 'support/levels_controller_shared_examples'
 RSpec.describe Alephant::Logger::LevelsController do
   describe '.should_log?' do
     subject(:loggable?) do
-      described_class.should_log?(
-        message_level: message_level,
-        desired_level: desired_level
-      )
+      described_class.should_log?(message_level, desired_level)
     end
 
     describe 'Message level' do


### PR DESCRIPTION
### [WS2020-617](https://jira.dev.bbc.co.uk/browse/WS2020-617)

This PR removes Ruby 1.9.3+ syntax 😭  which is unsupported in JRuby 1.7.x; used by dependants.